### PR TITLE
Cut the SGLOH runtime in about half by only generating the mask once …

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,29 +10,29 @@ int main(int argc, char** argv) {
     // processImage4 uses a rotated image with FLANN matching
     // processImage5 uses a scaled with BF matching
     // processImage6 uses a 45 degree rotation with BF matching
-    processImage4("ciri.jpg");
+    compareImages("img1.ppm", "img2.ppm");
 
 
-    //create imagematcher
-    ImageMatcher imageMatcher;
-    cv::Mat image = cv::imread("../rin.jpg", cv::IMREAD_GRAYSCALE);
-    cv::imshow("Query", image);
-
-    //Search images using sift
-//    std::cout << "Perform SIFT matching" << std::endl;
-//    std::vector<cv::Mat> siftImages = imageMatcher.siftMatch(image);
-//    std::cout << "Number of images above threshold: " << siftImages.size() << std::endl;
-//    for (int i = 0; i < siftImages.size(); i++) {
-//        cv::imshow("Image", siftImages[i]);
+//    //create imagematcher
+//    ImageMatcher imageMatcher;
+//    cv::Mat image = cv::imread("../rin.jpg", cv::IMREAD_GRAYSCALE);
+//    cv::imshow("Query", image);
+//
+//    //Search images using sift
+////    std::cout << "Perform SIFT matching" << std::endl;
+////    std::vector<cv::Mat> siftImages = imageMatcher.siftMatch(image);
+////    std::cout << "Number of images above threshold: " << siftImages.size() << std::endl;
+////    for (int i = 0; i < siftImages.size(); i++) {
+////        cv::imshow("Image", siftImages[i]);
+////        cv::waitKey(0);
+////    }
+//    //Search images using sGlOH2
+//    std::cout << "Perform sGLOH2 matching" << std::endl;
+//    std::vector<cv::Mat> sgloh2Images = imageMatcher.sGLOHMatch(image, M);
+//    std::cout << "Number of images above threshold: " << sgloh2Images.size() << std::endl;
+//    for (int i = 0; i < sgloh2Images.size(); i++) {
+//        cv::imshow("Image", sgloh2Images[i]);
 //        cv::waitKey(0);
 //    }
-    //Search images using sGlOH2
-    std::cout << "Perform sGLOH2 matching" << std::endl;
-    std::vector<cv::Mat> sgloh2Images = imageMatcher.sGLOHMatch(image, M);
-    std::cout << "Number of images above threshold: " << sgloh2Images.size() << std::endl;
-    for (int i = 0; i < sgloh2Images.size(); i++) {
-        cv::imshow("Image", sgloh2Images[i]);
-        cv::waitKey(0);
-    }
     return 0;
 }

--- a/src/sGLOH2.hpp
+++ b/src/sGLOH2.hpp
@@ -11,6 +11,7 @@ class sGLOH2 {
 private:
     int m;  // discretization of the rotation
     cv::Mat H1, H2;
+    std::vector<std::vector<cv::Mat>> region_masks;
 
 public:
     explicit sGLOH2(int m = 8);  // default number of bins to 8
@@ -19,12 +20,12 @@ public:
 
     cv::Mat compute_sGLOH(const cv::Mat& patch);
 
-    double distance(const cv::Mat& H_star1, const cv::Mat& H_star2);
+    static double distance(const cv::Mat& H_star1, const cv::Mat& H_star2);
 
     // Add more methods as needed for other operations, such as matching or orientation estimation
-    cv::Mat computeHistogram(const cv::Mat &region, int m);
+    //cv::Mat computeHistogram(const cv::Mat &region, int m);
 
-    cv::Mat cyclicShift(const cv::Mat &descriptor, int k);
+    static cv::Mat cyclicShift(const cv::Mat &descriptor, int k);
 
     cv::Mat compute_sGLOH_single(const cv::Mat &patch);
 
@@ -34,7 +35,7 @@ public:
 
     double cosine_similarity(const cv::Mat &H1, const cv::Mat &H2);
 
-    cv::Mat computeWeightedHistogram(const cv::Mat &orientation, const cv::Mat &magnitude, const cv::Mat &mask, int m);
+    //cv::Mat computeWeightedHistogram(const cv::Mat &orientation, const cv::Mat &magnitude, const cv::Mat &mask, int m);
 };
 
 #endif //SGLOH_OPENCV_SGLOH2_HPP


### PR DESCRIPTION
…and using parallelism in the descriptor calculation. Also made some modifications to the tests that use our distacne method instead of the BFMmatcher Which got fewer but higher quality matches in the process image function. Also updated documentation to get instructions on hover over.